### PR TITLE
Update EasyIterator to work with C++20

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,6 +1,14 @@
 name: Benchmark
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+    branches:
+      - master
+      - main
 
 jobs:
   build:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,6 +1,14 @@
 name: Install
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+    branches:
+      - master
+      - main
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,14 @@
 name: MacOS
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+    branches:
+      - master
+      - main
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
 
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -18,11 +18,11 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     
-    - name: Install clang-format
-      run: brew install clang-format
+    - name: Install format dependencies
+      run: pip3 install clang-format==14.0.6
 
     - name: configure
-      run: cmake -Htest -Bbuild
+      run: cmake -Stest -Bbuild
 
     - name: check style
       run: cmake --build build --target check-format

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,6 +1,14 @@
 name: Style
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+    branches:
+      - master
+      - main
 
 jobs:
   build:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,6 +1,14 @@
 name: Ubuntu
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+    branches:
+      - master
+      - main
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,14 @@
 name: Windows
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+    branches:
+      - master
+      - main
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .vscode
+.venv
 /build*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,16 +27,16 @@ CPMAddPackage(
 
 # ---- Header target ----
 
-FILE(GLOB_RECURSE headers CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/include/*.h")
+file(GLOB_RECURSE headers CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/include/*.h")
 add_library(EasyIterator-headers EXCLUDE_FROM_ALL ${headers})
-SET_TARGET_PROPERTIES(EasyIterator-headers PROPERTIES LINKER_LANGUAGE CXX)
+set_target_properties(EasyIterator-headers PROPERTIES LINKER_LANGUAGE CXX)
 
 # ---- Create library ----
 
 add_library(EasyIterator INTERFACE)
 
 target_compile_options(EasyIterator INTERFACE "$<$<BOOL:${MSVC}>:/permissive->")
-set_target_properties(EasyIterator PROPERTIES INTERFACE_COMPILE_FEATURES cxx_std_17)
+set_target_properties(EasyIterator PROPERTIES INTERFACE_COMPILE_FEATURES cxx_std_20)
 
 target_include_directories(EasyIterator
   INTERFACE 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ set_target_properties(EasyIterator-headers PROPERTIES LINKER_LANGUAGE CXX)
 add_library(EasyIterator INTERFACE)
 
 target_compile_options(EasyIterator INTERFACE "$<$<BOOL:${MSVC}>:/permissive->")
-set_target_properties(EasyIterator PROPERTIES INTERFACE_COMPILE_FEATURES cxx_std_20)
+set_target_properties(EasyIterator PROPERTIES INTERFACE_COMPILE_FEATURES cxx_std_17)
 
 target_include_directories(EasyIterator
   INTERFACE 

--- a/include/easy_iterator.h
+++ b/include/easy_iterator.h
@@ -182,8 +182,8 @@ namespace easy_iterator {
 
   template <class T, typename D> IteratorPrototype(const T &, const D &) -> IteratorPrototype<T, D>;
 
-  template <class T, typename D, typename C>
-  IteratorPrototype(const T &, const D &, const C &) -> IteratorPrototype<T, D, C>;
+  template <class T, typename D, typename C> IteratorPrototype(const T &, const D &, const C &)
+      -> IteratorPrototype<T, D, C>;
 
   namespace iterator_detail {
     struct WithState {
@@ -266,8 +266,8 @@ namespace easy_iterator {
 
   template <class T, typename F> Iterator(const T &, const F &) -> Iterator<T, F>;
 
-  template <class T, typename F, typename D>
-  Iterator(const T &, const F &, const D &) -> Iterator<T, F, D>;
+  template <class T, typename F, typename D> Iterator(const T &, const F &, const D &)
+      -> Iterator<T, F, D>;
 
   template <class T, typename F, typename D, typename C>
   Iterator(const T &, const F &, const D &, const C &) -> Iterator<T, F, D, C>;

--- a/include/easy_iterator.h
+++ b/include/easy_iterator.h
@@ -160,11 +160,22 @@ namespace easy_iterator {
     template <typename... LArgs, typename... RArgs>
     friend bool operator==(const IteratorPrototype<LArgs...> &lhs,
                            const IteratorPrototype<RArgs...> &rhs);
+
+    // required for C++17 or earlier
+    template <typename... LArgs, typename... RArgs>
+    friend bool operator!=(const IteratorPrototype<LArgs...> &lhs,
+                           const IteratorPrototype<RArgs...> &rhs);
   };
 
   template <typename... LArgs, typename... RArgs>
   bool operator==(const IteratorPrototype<LArgs...> &lhs, const IteratorPrototype<RArgs...> &rhs) {
     return lhs.compare(lhs.value, rhs.value);
+  }
+
+  // required for C++17 or earlier
+  template <typename... LArgs, typename... RArgs>
+  bool operator!=(const IteratorPrototype<LArgs...> &lhs, const IteratorPrototype<RArgs...> &rhs) {
+    return !(lhs == rhs);
   }
 
   template <class T> IteratorPrototype(const T &) -> IteratorPrototype<T>;
@@ -228,6 +239,9 @@ namespace easy_iterator {
 
     template <typename... Args>
     friend bool operator==(const Iterator<Args...> &lhs, const IterationEnd &);
+    // required for C++17 or earlier
+    template <typename... Args>
+    friend bool operator!=(const Iterator<Args...> &lhs, const IterationEnd &);
 
     explicit operator bool() const {
       if constexpr (Iterator::hasState) {
@@ -238,9 +252,14 @@ namespace easy_iterator {
     }
   };
 
-  template <typename... Args>
-  bool operator==(const Iterator<Args...> &lhs, const IterationEnd &) {
+  template <typename... Args> bool operator==(const Iterator<Args...> &lhs, const IterationEnd &) {
     return !static_cast<bool>(lhs);
+  }
+
+  // required for C++17 or earlier
+  template <typename... Args>
+  bool operator!=(const Iterator<Args...> &lhs, const IterationEnd &rhs) {
+    return !(lhs == rhs);
   }
 
   template <class T> Iterator(const T &) -> Iterator<T>;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,7 +16,7 @@ include(../cmake/CPM.cmake)
 CPMAddPackage(
   NAME doctest
   GITHUB_REPOSITORY onqtam/doctest
-  GIT_TAG 2.3.7
+  GIT_TAG v2.4.11
 )
 
 if (TEST_INSTALLED_VERSION)
@@ -40,7 +40,7 @@ file(GLOB sources CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/source/*.cpp)
 add_executable(EasyIteratorTests ${sources})
 target_link_libraries(EasyIteratorTests doctest EasyIterator)
 
-set_target_properties(EasyIteratorTests PROPERTIES CXX_STANDARD 17)
+set_target_properties(EasyIteratorTests PROPERTIES CXX_STANDARD 20)
 
 # enable compiler warnings
 if (NOT TEST_INSTALLED_VERSION)
@@ -53,11 +53,11 @@ endif()
 
 # ---- Add EasyIteratorTests ----
 
-ENABLE_TESTING() 
+enable_testing() 
 
 # Note: doctest and similar testing frameworks can automatically configure CMake tests
 # For other testing frameworks add the tests target instead:
-# ADD_TEST(EasyIteratorTests EasyIteratorTests)
+# add_test(EasyIteratorTests EasyIteratorTests)
 
 include(${doctest_SOURCE_DIR}/scripts/cmake/doctest.cmake)
 doctest_discover_tests(EasyIteratorTests)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,7 +40,7 @@ file(GLOB sources CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/source/*.cpp)
 add_executable(EasyIteratorTests ${sources})
 target_link_libraries(EasyIteratorTests doctest EasyIterator)
 
-set_target_properties(EasyIteratorTests PROPERTIES CXX_STANDARD 20)
+set_target_properties(EasyIteratorTests PROPERTIES CXX_STANDARD 17)
 
 # enable compiler warnings
 if (NOT TEST_INSTALLED_VERSION)


### PR DESCRIPTION
## Summary

This PR updates the excellent **EasyIterator** library to work with C++20 (along with a few minor changes to `CMakeLists.txt` files and some small comment fixes... sorry I couldn't help myself 😅🙈).

## Detail

C++20 comes with an enormous overhaul to how comparisons work (there's an excellent blogpost about this by Barry Revzin you can find [here](https://brevzin.github.io/c++/2019/07/28/comparisons-cpp20/)).

When using C++20 with **EasyIterator** (you can do this by changing `cxx_std_17` to `cxx_std_20` in the root `CMakeLists.txt` file when using the library or building the tests), compiling **EasyIterator** as-is unfortunately no longer compiles. This is down to changes relating to [lookup rules](https://brevzin.github.io/c++/2019/07/28/comparisons-cpp20/#specific-lookup-rules), and reversibility and rewriting in C++20. To workaround these changes I've moved the equality operators to friend functions which solves the specific issue relating to reversibility, namely...

```
.../easy_iterator.h:400:24: error: ISO C++20 considers use of overloaded operator '!=' (with operand types 'easy_iterator::Iterator<std::tuple<easy_iterator::RangeIterator<int>, std::__wrap_iter<int *>>, easy_iterator::increment::ByTupleIncrement, easy_iterator::dereference::ByTupleDereference, easy_iterator::compare::ByLastTupleElementMatch>' and 'easy_iterator::Iterator<std::tuple<easy_iterator::RangeIterator<int>, std::__wrap_iter<int *>>, easy_iterator::increment::ByTupleIncrement, easy_iterator::dereference::ByTupleDereference, easy_iterator::compare::ByLastTupleElementMatch>') to be ambiguous despite there being a unique best viable function with non-reversed arguments [-Werror,-Wambiguous-reversed-operator]

.../easy_iterator.cpp:218:5: note: in instantiation of function template specialization 'easy_iterator::copy<easy_iterator::WrappedIterator<easy_iterator::RangeIterator<int>>, std::vector<int>, easy_iterator::dereference::ByValueReference>' requested here
  218 |     copy(range(10), vec);
      |     ^
.../easy_iterator.h:162:38: note: candidate function with non-reversed arguments
  162 |     template <typename... Args> bool operator!=(const IteratorPrototype<Args...> &other) const {
      |                                      ^
.../easy_iterator.h:159:38: note: ambiguous candidate function with reversed arguments
  159 |     template <typename... Args> bool operator==(const IteratorPrototype<Args...> &other) const {
```

I've run the tests which all pass with the updated changes:

```
[doctest] doctest version is "2.4.11"
[doctest] run with "--help" for options
===============================================================================
[doctest] test cases:  12 |  12 passed | 0 failed | 0 skipped
[doctest] assertions: 329 | 329 passed | 0 failed |
[doctest] Status: SUCCESS!
```

## Note

I have also tested these changes with C++17 to ensure the updates don't break any clients who are not yet ready to upgrade to C++20 (you can see the C++17 changes in commit a79b099b02773aec648da7d4a4d81a24397136ab). One cool thing in C++20 is you can omit the `!=` operator if `==` is provided as it will be automatically provided for you. I've kept the usage requirements for the library as C++17 even though now it will work with C++20.

If you don't care about C++ 20 no worries, feel free to close this PR, but I'll be using this branch out of my fork for the foreseeable future I'm sure 😅.

I'd also like to quickly say this is a great library and one I've enjoyed using for many years!